### PR TITLE
Add dashboard credit meter and Pro upsell messaging

### DIFF
--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { type CSSProperties, useEffect, useState } from 'react';
 import useSWR from 'swr';
 import Header from '../components/Header';
 import GenerationForm from '../components/GenerationForm';
@@ -43,7 +43,39 @@ export default function DashboardPage() {
     return null;
   }
 
-  const remaining = Math.max(0, 2 - data.user.resumeCount);
+  const maxFreeCredits = 2;
+  const remaining = Math.max(0, maxFreeCredits - data.user.resumeCount);
+  const usedCredits = Math.min(data.user.resumeCount, maxFreeCredits);
+  const usagePercent = data.user.isPro
+    ? 100
+    : Math.round((usedCredits / maxFreeCredits) * 100);
+  const progressStyle: CSSProperties = {
+    ['--progress' as any]: `${usagePercent}%`
+  };
+
+  const proFeatures = [
+    {
+      title: 'Unlimited keyword gap analysis',
+      description: 'Reveal the exact phrases missing from your resume for every job posting.',
+      roi: 'Save ~$39/mo versus separate SEO tooling.',
+      tooltip:
+        'Upgrade to instantly surface ATS keywords so you stop spending hours rewriting each resume.'
+    },
+    {
+      title: '1-click tailored cover letters',
+      description: 'Spin up recruiter-ready letters that mirror your resume in seconds.',
+      roi: 'Win back 3+ hours every week you would normally spend drafting letters.',
+      tooltip:
+        'Members report landing interviews twice as fast when their cover letters echo resume keywords.'
+    },
+    {
+      title: 'Priority export & tracking',
+      description: 'Export unlimited PDF/Word versions and track which ones perform best.',
+      roi: 'Avoid $20/job board fees by reusing your best converting resume instantly.',
+      tooltip:
+        'Know which tailored resumes convert so you invest time only where interviews happen.'
+    }
+  ];
 
   const handleGenerated = () => {
     mutate();
@@ -66,19 +98,77 @@ export default function DashboardPage() {
     <>
       <Header />
       <main className="container" style={{ padding: '3rem 0 5rem', display: 'grid', gap: '2rem' }}>
-        <section>
-          <h1 style={{ marginBottom: '0.5rem' }}>Welcome back, {data.user.email}</h1>
-          <p style={{ color: 'var(--muted)' }}>
-            {data.user.isPro
-              ? 'You have unlimited tailored resumes with your Pro membership.'
-              : `You can tailor ${remaining} more resume${remaining === 1 ? '' : 's'} for free.`}
-          </p>
-          {!data.user.isPro && (
-            <button className="primary" type="button" style={{ marginTop: '1rem' }} onClick={handleUpgrade}>
-              Upgrade to Pro for unlimited resumes
-            </button>
-          )}
+        <section className="dashboard-intro card">
+          <div className="intro-copy">
+            <h1>Welcome back, {data.user.email}</h1>
+            <p className="intro-subhead">
+              {data.user.isPro
+                ? 'You have unlimited tailored resumes with your Pro membership.'
+                : `You can tailor ${remaining} more resume${remaining === 1 ? '' : 's'} for free.`}
+            </p>
+            {!data.user.isPro && (
+              <>
+                <button className="primary upgrade-button" type="button" onClick={handleUpgrade}>
+                  Upgrade to Pro for unlimited resumes
+                </button>
+                <p className="upgrade-footnote">
+                  Unlock unlimited keyword gap analysis, instant cover letters, and export history so each
+                  application earns a faster response.
+                </p>
+              </>
+            )}
+          </div>
+          <div className={`credit-meter${data.user.isPro ? ' credit-meter--pro' : ''}`}>
+            <div
+              className="credit-ring"
+              style={progressStyle}
+              role="img"
+              aria-label={
+                data.user.isPro
+                  ? 'You are on Pro. Unlimited credits available.'
+                  : `${usagePercent}% of your free credits have been used.`
+              }
+            >
+              <span className="credit-count">
+                {data.user.isPro ? '∞' : `${usedCredits}/${maxFreeCredits}`}
+              </span>
+            </div>
+            <p className="credit-meter__label">
+              {data.user.isPro ? 'Pro access unlocked' : 'Free credits used'}
+            </p>
+            {!data.user.isPro && (
+              <p className="credit-meter__caption">Upgrade to refill credits and keep your application momentum.</p>
+            )}
+          </div>
         </section>
+
+        {!data.user.isPro && (
+          <>
+            <div className="upsell-banner" role="note">
+              <strong>Time is money.</strong> Upgrading once saves hours each week and pays for itself after two
+              interviews.
+            </div>
+            <section className="pro-feature-grid" aria-label="Pro plan benefits">
+              {proFeatures.map((feature) => (
+                <article
+                  key={feature.title}
+                  className="locked-tile"
+                  data-tooltip={feature.tooltip}
+                  tabIndex={0}
+                >
+                  <div className="locked-tile__header">
+                    <span className="lock-badge" aria-hidden="true">
+                      🔒 Pro
+                    </span>
+                    <h3>{feature.title}</h3>
+                  </div>
+                  <p>{feature.description}</p>
+                  <p className="feature-roi">{feature.roi}</p>
+                </article>
+              ))}
+            </section>
+          </>
+        )}
 
         <GenerationForm isPro={data.user.isPro} remaining={remaining} onGenerated={handleGenerated} />
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -147,3 +147,213 @@ form .field {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
+
+.dashboard-intro {
+  display: grid;
+  gap: 2rem;
+  align-items: center;
+}
+
+@media (min-width: 768px) {
+  .dashboard-intro {
+    grid-template-columns: minmax(0, 1.75fr) minmax(0, 1fr);
+  }
+}
+
+.intro-copy h1 {
+  margin: 0 0 0.5rem;
+}
+
+.intro-subhead {
+  color: var(--muted);
+  margin: 0;
+}
+
+.upgrade-button {
+  margin-top: 1rem;
+}
+
+.upgrade-footnote {
+  margin: 0.75rem 0 0;
+  color: var(--muted);
+  max-width: 28rem;
+  line-height: 1.5;
+  font-size: 0.9rem;
+}
+
+.credit-meter {
+  display: grid;
+  place-items: center;
+  gap: 0.5rem;
+  text-align: center;
+}
+
+.credit-meter--pro {
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.08), rgba(99, 102, 241, 0.12));
+  border-radius: 20px;
+  padding: 1.25rem;
+}
+
+.credit-ring {
+  --progress: 0%;
+  width: 140px;
+  height: 140px;
+  border-radius: 50%;
+  background: conic-gradient(var(--primary) var(--progress), rgba(37, 99, 235, 0.12) 0);
+  display: grid;
+  place-items: center;
+  position: relative;
+  transition: background 0.3s ease;
+}
+
+.credit-ring::after {
+  content: '';
+  width: 110px;
+  height: 110px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: inset 0 0 0 1px rgba(37, 99, 235, 0.08);
+}
+
+.credit-ring .credit-count {
+  position: relative;
+  z-index: 1;
+  font-weight: 700;
+  font-size: 1.25rem;
+  color: var(--primary-dark);
+}
+
+.credit-meter__label {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
+.credit-meter__caption {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.85rem;
+  max-width: 14rem;
+  line-height: 1.4;
+}
+
+.upsell-banner {
+  border-radius: 18px;
+  padding: 1.25rem 1.5rem;
+  background: linear-gradient(135deg, rgba(254, 243, 199, 0.95), rgba(219, 234, 254, 0.9));
+  border: 1px solid rgba(250, 204, 21, 0.5);
+  box-shadow: 0 20px 48px -28px rgba(15, 23, 42, 0.4);
+  color: #7c2d12;
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  align-items: baseline;
+  line-height: 1.6;
+}
+
+.upsell-banner strong {
+  color: #92400e;
+}
+
+.pro-feature-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.locked-tile {
+  position: relative;
+  border-radius: 18px;
+  padding: 1.5rem;
+  background: #fff;
+  border: 1px dashed rgba(37, 99, 235, 0.35);
+  box-shadow: 0 24px 48px -32px rgba(15, 23, 42, 0.35);
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+  outline: none;
+}
+
+.locked-tile:hover,
+.locked-tile:focus-visible {
+  transform: translateY(-4px);
+  border-color: rgba(37, 99, 235, 0.75);
+  box-shadow: 0 28px 60px -32px rgba(37, 99, 235, 0.45);
+}
+
+.locked-tile__header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.locked-tile h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.locked-tile p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.feature-roi {
+  margin-top: 0.75rem;
+  font-weight: 600;
+  color: var(--primary-dark);
+}
+
+.lock-badge {
+  background: rgba(37, 99, 235, 0.14);
+  color: var(--primary-dark);
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.locked-tile::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 1rem);
+  transform: translate(-50%, 10px);
+  background: rgba(17, 24, 39, 0.95);
+  color: white;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  box-shadow: 0 16px 32px -20px rgba(15, 23, 42, 0.65);
+  width: min(260px, 90vw);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  font-size: 0.85rem;
+  line-height: 1.4;
+  z-index: 10;
+}
+
+.locked-tile::before {
+  content: '';
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 0.75rem);
+  transform: translateX(-50%);
+  border: 8px solid transparent;
+  border-top-color: rgba(17, 24, 39, 0.95);
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  z-index: 9;
+}
+
+.locked-tile:hover::after,
+.locked-tile:focus-visible::after {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+.locked-tile:hover::before,
+.locked-tile:focus-visible::before {
+  opacity: 1;
+}


### PR DESCRIPTION
## Summary
- add a radial credit meter, ROI copy, and upgrade CTA improvements to the dashboard hero
- introduce locked Pro feature tiles with contextual tooltips to highlight time and cost savings
- style the new meter, upsell banner, and Pro tiles so the upgrade surfaces stand out without being intrusive

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9b26374dc832ca2c64797492f8a57