### PR TITLE
Add resume personalization controls and persist preferences

### DIFF
--- a/components/GenerationForm.tsx
+++ b/components/GenerationForm.tsx
@@ -10,9 +10,31 @@ interface GenerationResponse {
   result: string;
 }
 
+const toneOptions = [
+  { value: 'professional', label: 'Professional polish' },
+  { value: 'friendly', label: 'Friendly and warm' },
+  { value: 'bold', label: 'Bold and energetic' }
+];
+
+const seniorityOptions = [
+  { value: 'entry-level', label: 'Entry-level focus' },
+  { value: 'mid-level', label: 'Mid-level contributor' },
+  { value: 'senior', label: 'Senior leadership' }
+];
+
+const formatOptions = [
+  { value: 'traditional', label: 'Traditional chronological' },
+  { value: 'modern', label: 'Modern impact-driven' },
+  { value: 'compact', label: 'Compact one-page' }
+];
+
 export default function GenerationForm({ isPro, remaining, onGenerated }: GenerationFormProps) {
   const [jobDescription, setJobDescription] = useState('');
   const [resume, setResume] = useState('');
+  const [tone, setTone] = useState(toneOptions[0].value);
+  const [seniority, setSeniority] = useState(seniorityOptions[1].value);
+  const [format, setFormat] = useState(formatOptions[1].value);
+  const [includeCoverLetter, setIncludeCoverLetter] = useState(false);
   const [result, setResult] = useState('');
   const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(false);
@@ -27,6 +49,7 @@ export default function GenerationForm({ isPro, remaining, onGenerated }: Genera
   const handleSubmit = async (event: FormEvent) => {
     event.preventDefault();
     setError('');
+    setResult('');
 
     if (!isPro && remaining <= 0) {
       setError('You have reached your free limit. Upgrade to Pro for unlimited tailoring.');
@@ -40,7 +63,7 @@ export default function GenerationForm({ isPro, remaining, onGenerated }: Genera
         headers: {
           'Content-Type': 'application/json'
         },
-        body: JSON.stringify({ jobDescription, resume })
+        body: JSON.stringify({ jobDescription, resume, tone, seniority, format, includeCoverLetter })
       });
 
       if (!response.ok) {
@@ -63,8 +86,8 @@ export default function GenerationForm({ isPro, remaining, onGenerated }: Genera
       <form onSubmit={handleSubmit}>
         <h2 style={{ marginTop: 0 }}>Tailor your resume</h2>
         <p style={{ color: 'var(--muted)' }}>
-          Paste the job description and your current resume. Our AI will highlight the most relevant
-          skills, tone, and keywords in seconds.
+          Paste the job description, choose how bold or friendly you want to sound, and we&apos;ll rework
+          your resume to match. You can even append a cover letter in the same pass.
         </p>
 
         <div className="field">
@@ -91,6 +114,88 @@ export default function GenerationForm({ isPro, remaining, onGenerated }: Genera
           />
         </div>
 
+        <div
+          style={{
+            margin: '2rem 0',
+            padding: '1.5rem',
+            border: '1px solid var(--border)',
+            borderRadius: '12px',
+            background: '#f8fafc'
+          }}
+        >
+          <h3 style={{ margin: '0 0 1rem', fontSize: '1.1rem' }}>Personalize the rewrite</h3>
+          <p style={{ color: 'var(--muted)', margin: '0 0 1.5rem', fontSize: '0.95rem' }}>
+            These preferences will be saved with your history so you can revisit what worked best for
+            each application.
+          </p>
+
+          <div
+            style={{
+              display: 'grid',
+              gap: '1.5rem',
+              gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))'
+            }}
+          >
+            <div className="field" style={{ marginBottom: 0 }}>
+              <label htmlFor="tone">Resume tone</label>
+              <select id="tone" value={tone} onChange={(event) => setTone(event.target.value)}>
+                {toneOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+              <p className="helper">Dial up the polish, warmth, or energy in the language.</p>
+            </div>
+
+            <div className="field" style={{ marginBottom: 0 }}>
+              <label htmlFor="seniority">Seniority focus</label>
+              <select
+                id="seniority"
+                value={seniority}
+                onChange={(event) => setSeniority(event.target.value)}
+              >
+                {seniorityOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+              <p className="helper">Make sure accomplishments match the level of the role.</p>
+            </div>
+
+            <div className="field" style={{ marginBottom: 0 }}>
+              <label htmlFor="format">Resume format</label>
+              <select id="format" value={format} onChange={(event) => setFormat(event.target.value)}>
+                {formatOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+              <p className="helper">Choose the structure and pacing that fits the audience.</p>
+            </div>
+          </div>
+
+          <div className="field" style={{ margin: '1.5rem 0 0' }}>
+            <label htmlFor="includeCoverLetter" style={{ marginBottom: '0.75rem' }}>
+              Cover letter companion
+            </label>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+              <input
+                id="includeCoverLetter"
+                type="checkbox"
+                checked={includeCoverLetter}
+                onChange={(event) => setIncludeCoverLetter(event.target.checked)}
+                style={{ width: '1.2rem', height: '1.2rem' }}
+              />
+              <span style={{ color: 'var(--muted)', fontSize: '0.95rem' }}>
+                Append a tailored cover letter after the resume using the same tone.
+              </span>
+            </div>
+          </div>
+        </div>
+
         <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
           <button className="primary" type="submit" disabled={isLoading || isDisabled}>
             {isLoading ? 'Tailoring…' : 'Tailor now'}
@@ -110,6 +215,7 @@ export default function GenerationForm({ isPro, remaining, onGenerated }: Genera
           <h3>Tailored resume</h3>
           <p style={{ color: 'var(--muted)' }}>
             Copy this version directly into your application tracking system or download it as a PDF.
+            If you requested a cover letter, you&apos;ll find it neatly appended below the resume.
           </p>
           <pre
             style={{

--- a/components/GenerationHistory.tsx
+++ b/components/GenerationHistory.tsx
@@ -5,11 +5,33 @@ interface GenerationItem {
   jobDescription: string;
   generatedResume: string;
   createdAt: string;
+  tone: 'professional' | 'friendly' | 'bold';
+  seniority: 'entry-level' | 'mid-level' | 'senior';
+  format: 'traditional' | 'modern' | 'compact';
+  includeCoverLetter: boolean;
 }
 
 interface HistoryResponse {
   generations: GenerationItem[];
 }
+
+const toneLabels: Record<GenerationItem['tone'], string> = {
+  professional: 'Professional polish',
+  friendly: 'Friendly & warm',
+  bold: 'Bold & energetic'
+};
+
+const seniorityLabels: Record<GenerationItem['seniority'], string> = {
+  'entry-level': 'Entry-level focus',
+  'mid-level': 'Mid-level contributor',
+  senior: 'Senior leadership'
+};
+
+const formatLabels: Record<GenerationItem['format'], string> = {
+  traditional: 'Traditional chronological',
+  modern: 'Modern impact-driven',
+  compact: 'Compact one-page'
+};
 
 const fetcher = async (url: string) => {
   const res = await fetch(url);
@@ -47,6 +69,12 @@ export default function GenerationHistory({ refreshKey }: { refreshKey: number }
           <div key={generation.id} style={{ borderBottom: '1px solid var(--border)', paddingBottom: '1.5rem' }}>
             <p style={{ color: 'var(--muted)', fontSize: '0.85rem', marginBottom: '0.75rem' }}>
               {new Date(generation.createdAt).toLocaleString()}
+            </p>
+            <p style={{ color: 'var(--muted)', fontSize: '0.9rem', margin: '0 0 0.75rem' }}>
+              Tone: <strong style={{ color: 'var(--foreground)' }}>{toneLabels[generation.tone]}</strong> · Focus:{' '}
+              <strong style={{ color: 'var(--foreground)' }}>{seniorityLabels[generation.seniority]}</strong> · Format:{' '}
+              <strong style={{ color: 'var(--foreground)' }}>{formatLabels[generation.format]}</strong> · Cover letter:{' '}
+              <strong style={{ color: 'var(--foreground)' }}>{generation.includeCoverLetter ? 'Included' : 'Not included'}</strong>
             </p>
             <details>
               <summary style={{ cursor: 'pointer', fontWeight: 600 }}>View tailored resume</summary>

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,6 +26,10 @@ model ResumeGeneration {
   jobDescription   String
   originalResume   String
   generatedResume  String
+  tone             String   @default("professional")
+  seniority        String   @default("mid-level")
+  format           String   @default("modern")
+  includeCoverLetter Boolean @default(false)
   createdAt        DateTime @default(now())
   user             User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   userId           String

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -60,7 +60,8 @@ button.primary:hover {
 }
 
 input,
-textarea {
+textarea,
+select {
   width: 100%;
   padding: 0.75rem 1rem;
   border-radius: 12px;
@@ -71,6 +72,21 @@ textarea {
   resize: vertical;
 }
 
+select {
+  appearance: none;
+  background-image: linear-gradient(45deg, transparent 50%, var(--muted) 50%),
+    linear-gradient(135deg, var(--muted) 50%, transparent 50%);
+  background-position: calc(100% - 20px) calc(1.2rem), calc(100% - 15px) calc(1.2rem);
+  background-size: 5px 5px, 5px 5px;
+  background-repeat: no-repeat;
+}
+
+select:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+}
+
 label {
   font-weight: 600;
   display: block;
@@ -79,6 +95,12 @@ label {
 
 form .field {
   margin-bottom: 1.5rem;
+}
+
+form .helper {
+  color: var(--muted);
+  font-size: 0.85rem;
+  margin-top: 0.5rem;
 }
 
 .error {


### PR DESCRIPTION
## Summary
- add tone, seniority, format, and cover letter controls to the tailoring form and send them to the API
- validate new preferences, incorporate them into the OpenAI prompt, and store them on each resume generation
- surface saved settings in history and refresh select styling so the new controls match the existing cards

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9b26cc5a4832c829bbc1a770e4af0